### PR TITLE
feat: allow for the retrieval of plugin schema for loaded plugins

### DIFF
--- a/plugin/testdata/acl.lua
+++ b/plugin/testdata/acl.lua
@@ -1,0 +1,40 @@
+local typedefs = require "kong.db.schema.typedefs"
+
+
+return {
+  name = "acl",
+  fields = {
+    { consumer = typedefs.no_consumer },
+    { protocols = typedefs.protocols_http },
+    { config = {
+        type = "record",
+        fields = {
+          { allow = { type = "array", elements = { type = "string" }, }, },
+          { deny = { type = "array", elements = { type = "string" }, }, },
+          { hide_groups_header = { type = "boolean", required = true, default = false }, },
+        },
+        shorthand_fields = {
+          -- deprecated forms, to be removed in Kong 3.0
+          { blacklist = {
+              type = "array",
+              elements = { type = "string", is_regex = true },
+              func = function(value)
+                return { deny = value }
+              end,
+          }, },
+          { whitelist = {
+              type = "array",
+              elements = { type = "string", is_regex = true },
+              func = function(value)
+                return { allow = value }
+              end,
+          }, },
+        },
+      }
+    }
+  },
+  entity_checks = {
+    { only_one_of = { "config.allow", "config.deny" }, },
+    { at_least_one_of = { "config.allow", "config.deny" }, },
+  },
+}

--- a/plugin/testdata/http-log.lua
+++ b/plugin/testdata/http-log.lua
@@ -1,0 +1,55 @@
+local typedefs = require "kong.db.schema.typedefs"
+local url = require "patched.url"
+
+return {
+  name = "http-log",
+  fields = {
+    { protocols = typedefs.protocols },
+    { config = {
+        type = "record",
+        fields = {
+          -- NOTE: any field added here must be also included in the handler's get_queue_id method
+          { http_endpoint = typedefs.url({ required = true }) },
+          { method = { type = "string", default = "POST", one_of = { "POST", "PUT", "PATCH" }, }, },
+          { content_type = { type = "string", default = "application/json", one_of = { "application/json" }, }, },
+          { timeout = { type = "number", default = 10000 }, },
+          { keepalive = { type = "number", default = 60000 }, },
+          { retry_count = { type = "integer", default = 10 }, },
+          { queue_size = { type = "integer", default = 1 }, },
+          { flush_timeout = { type = "number", default = 2 }, },
+          { headers = typedefs.headers {
+            keys = typedefs.header_name {
+              match_none = {
+                {
+                  pattern = "^[Hh][Oo][Ss][Tt]$",
+                  err = "cannot contain 'Host' header",
+                },
+                {
+                  pattern = "^[Cc][Oo][Nn][Tt][Ee][Nn][Tt]%-[Ll][Ee][nn][Gg][Tt][Hh]$",
+                  err = "cannot contain 'Content-Length' header",
+                },
+                {
+                  pattern = "^[Cc][Oo][Nn][Tt][Ee][Nn][Tt]%-[Tt][Yy][Pp][Ee]$",
+                  err = "cannot contain 'Content-Type' header",
+                },
+              },
+            },
+          } },
+          { custom_fields_by_lua = typedefs.lua_code },
+        },
+        custom_validator = function(config)
+          -- check no double userinfo + authorization header
+          local parsed_url = url.parse(config.http_endpoint)
+          if parsed_url.userinfo and config.headers then
+            for hname, hvalue in pairs(config.headers) do
+              if hname:lower() == "authorization" then
+                return false, "specifying both an 'Authorization' header and user info in 'http_endpoint' is not allowed"
+              end
+            end
+          end
+          return true
+        end,
+      },
+    },
+  },
+}

--- a/plugin/testdata/udp-log.lua
+++ b/plugin/testdata/udp-log.lua
@@ -1,0 +1,16 @@
+local typedefs = require "kong.db.schema.typedefs"
+
+return {
+  name = "udp-log",
+  fields = {
+    { protocols = typedefs.protocols },
+    { config = {
+        type = "record",
+        fields = {
+          { host = typedefs.host({ required = true }) },
+          { port = typedefs.port({ required = true }) },
+          { timeout = { type = "number", default = 10000 }, },
+          { custom_fields_by_lua = typedefs.lua_code },
+    }, }, },
+  },
+}

--- a/plugin/validator.go
+++ b/plugin/validator.go
@@ -29,3 +29,7 @@ func (v *Validator) Validate(pluginInstance string) error {
 func (v *Validator) ProcessAutoFields(pluginInstance string) (string, error) {
 	return v.vm.CallByParams("process_auto_fields", pluginInstance)
 }
+
+func (v *Validator) SchemaAsJSON(schemaName string) (string, error) {
+	return v.vm.CallByParams("schema_as_json", schemaName)
+}

--- a/plugin/validator_test.go
+++ b/plugin/validator_test.go
@@ -20,7 +20,7 @@ type KongPlugin struct {
 	Tags      []string               `json:"tags,omitempty" yaml:"tags,omitempty"`
 }
 
-type KongPluginConfig struct {
+type KongPluginSchema struct {
 	Fields []map[string]interface{} `json:"fields,omitempty" yaml:"fields,omitempty"`
 }
 
@@ -181,8 +181,11 @@ func TestValidator_ProcessAutoFields(t *testing.T) {
 
 func TestValidator_SchemaAsJSON(t *testing.T) {
 	schemaNames := []string{
+		"acl",
+		"http-log",
 		"key-auth",
 		"rate-limiting",
+		"udp-log",
 	}
 	v, err := NewValidator()
 	assert.Nil(t, err)
@@ -196,9 +199,131 @@ func TestValidator_SchemaAsJSON(t *testing.T) {
 		for _, schemaName := range schemaNames {
 			schema, err := v.SchemaAsJSON(schemaName)
 			assert.Nil(t, err)
-			var kongPluginConfig KongPluginConfig
+			var kongPluginConfig KongPluginSchema
 			assert.Nil(t, json.Unmarshal([]byte(schema), &kongPluginConfig))
 		}
+	})
+
+	t.Run("validate schema for known good plugin [udp-log]", func(t *testing.T) {
+		schema, err := v.SchemaAsJSON("udp-log")
+		assert.Nil(t, err)
+		var kongPluginConfig KongPluginSchema
+		assert.Nil(t, json.Unmarshal([]byte(schema), &kongPluginConfig))
+		assert.EqualValues(t, 2, len(kongPluginConfig.Fields))
+
+		// Parse using DOM style with the map[string]interface{}
+		// This is simpler than trying to stuff a dynamic array into a static
+		// structure
+		for _, field := range kongPluginConfig.Fields {
+			if v := field["config"]; v != nil {
+				config, ok := v.(map[string]interface{})
+				assert.True(t, ok)
+				assert.EqualValues(t, 3, len(config)) // required = true (auto field)
+				assert.EqualValues(t, true, config["required"])
+				assert.EqualValues(t, "record", config["type"])
+				configFields, ok := config["fields"].([]interface{})
+				assert.True(t, ok)
+				assert.EqualValues(t, 4, len(configFields))
+				for _, configField := range configFields {
+					option, ok := configField.(map[string]interface{})
+					assert.True(t, ok)
+					if w := option["custom_fields_by_lua"]; w != nil {
+						customFieldsByLua, ok := w.(map[string]interface{})
+						assert.True(t, ok)
+						assert.EqualValues(t, 3, len(customFieldsByLua))
+						keys, ok := customFieldsByLua["keys"].(map[string]interface{})
+						assert.True(t, ok)
+						assert.EqualValues(t, 2, len(keys))
+						values, ok := customFieldsByLua["values"].(map[string]interface{})
+						assert.True(t, ok)
+						assert.EqualValues(t, 2, len(keys))
+						assert.EqualValues(t, 1, keys["len_min"])
+						assert.EqualValues(t, "string", keys["type"])
+						assert.EqualValues(t, "map", customFieldsByLua["type"])
+						assert.EqualValues(t, 1, values["len_min"])
+						assert.EqualValues(t, "string", values["type"])
+					} else if w := option["host"]; w != nil {
+						host, ok := w.(map[string]interface{})
+						assert.True(t, ok)
+						assert.EqualValues(t, 2, len(host))
+						assert.EqualValues(t, true, host["required"])
+						assert.EqualValues(t, "string", host["type"])
+					} else if w := option["port"]; w != nil {
+						port, ok := w.(map[string]interface{})
+						assert.True(t, ok)
+						assert.EqualValues(t, 3, len(port))
+						assert.EqualValues(t, true, port["required"])
+						assert.EqualValues(t, "integer", port["type"])
+						assert.ElementsMatch(t, []float64{0, 65535}, port["between"])
+					} else if w := option["timeout"]; w != nil {
+						timeout, ok := w.(map[string]interface{})
+						assert.True(t, ok)
+						assert.EqualValues(t, 2, len(timeout))
+						assert.EqualValues(t, 10000, timeout["default"])
+						assert.EqualValues(t, "number", timeout["type"])
+					} else {
+						assert.Fail(t, "invalid config.fields for udp-log")
+					}
+				}
+			} else if v := field["protocols"]; v != nil {
+				protocols, ok := v.(map[string]interface{})
+				assert.True(t, ok)
+				assert.EqualValues(t, 4, len(protocols))
+				assert.ElementsMatch(t, []string{"grpc", "grpcs", "http", "https"},
+					protocols["default"])
+				if w := protocols["elements"]; w != nil {
+					elements, ok := w.(map[string]interface{})
+					assert.True(t, ok)
+					assert.EqualValues(t, 2, len(elements))
+					assert.ElementsMatch(t, []string{"grpc", "grpcs", "http", "https", "tcp", "tls", "udp"},
+						elements["one_of"])
+					assert.EqualValues(t, "string", elements["type"])
+				} else {
+					assert.Fail(t, "missing protocol.elements for udp-log")
+				}
+				assert.EqualValues(t, true, protocols["required"])
+				assert.EqualValues(t, "set", protocols["type"])
+			} else {
+				assert.Fail(t, "invalid item in fields for udp-log")
+			}
+		}
+	})
+
+	t.Run("ensure functions are removed before returning schema", func(t *testing.T) {
+		schema, err := v.SchemaAsJSON("acl")
+		assert.Nil(t, err)
+		var kongPluginConfig KongPluginSchema
+		assert.Nil(t, json.Unmarshal([]byte(schema), &kongPluginConfig))
+		assert.EqualValues(t, 3, len(kongPluginConfig.Fields))
+
+		shorthandFieldsValidated := false
+		for _, field := range kongPluginConfig.Fields {
+			if v := field["config"]; v != nil {
+				config, ok := v.(map[string]interface{})
+				assert.True(t, ok)
+				assert.EqualValues(t, 4, len(config)) // required = true (auto field)
+				if w := config["shorthand_fields"]; w != nil {
+					shorthandFields, ok := w.([]interface{})
+					assert.True(t, ok)
+					assert.EqualValues(t, 2, len(shorthandFields))
+					for _, shorthandField := range shorthandFields {
+						options, ok := shorthandField.(map[string]interface{})
+						assert.True(t, ok)
+						assert.EqualValues(t, 1, len(options))
+
+						// func field should be removed from blacklist and whitelist
+						for _, option := range options {
+							x, ok := option.(map[string]interface{})
+							assert.True(t, ok)
+							assert.EqualValues(t, 2, len(x))
+							assert.Nil(t, x["func"])
+						}
+					}
+					shorthandFieldsValidated = true
+				}
+			}
+		}
+		assert.True(t, shorthandFieldsValidated, "failed to parse config.shorthand_fields")
 	})
 
 	t.Run("returns error when specifying unknown plugin", func(t *testing.T) {


### PR DESCRIPTION
Calling `SchemaAsJSON` after `LoadSchema` has been executed for plugins will return the plugin configuration schema. This can be used for UI generation; similar to the endpoint `/schema/plugins/:name` Kong Gateway provides.

### TODO

- [x] - Add more tests for `SchemaAsJSON`