### PR TITLE
feat: return plugin name in call to LoadSchema

### DIFF
--- a/cmd/goks.go
+++ b/cmd/goks.go
@@ -23,7 +23,7 @@ func main() {
 	if err != nil {
 		log.Fatalln("failed to read schema file:", err)
 	}
-	err = validator.LoadSchema(string(schema))
+	_, err = validator.LoadSchema(string(schema))
 	if err != nil {
 		log.Fatalln("failed to load schema:", err)
 	}

--- a/internal/vm/setup.go
+++ b/internal/vm/setup.go
@@ -72,6 +72,7 @@ _G["load_plugin_schema"] = function(plugin_schema_string)
   if not ok then
     return nil, "error initializing schema for plugin: " .. err
   end
+  return plugin_name, nil
 end
 
 -- Remove functions from a schema definition so that

--- a/plugin/validator.go
+++ b/plugin/validator.go
@@ -16,9 +16,9 @@ func NewValidator() (*Validator, error) {
 	return &Validator{vm: vm}, nil
 }
 
-func (v *Validator) LoadSchema(schema string) error {
-	_, err := v.vm.CallByParams("load_plugin_schema", schema)
-	return err
+func (v *Validator) LoadSchema(schema string) (string, error) {
+	pluginName, err := v.vm.CallByParams("load_plugin_schema", schema)
+	return pluginName, err
 }
 
 func (v *Validator) Validate(pluginInstance string) error {

--- a/plugin/validator_test.go
+++ b/plugin/validator_test.go
@@ -31,17 +31,22 @@ func TestValidator_LoadSchema(t *testing.T) {
 	t.Run("loads a good schema", func(t *testing.T) {
 		schema, err := ioutil.ReadFile("testdata/key-auth.lua")
 		assert.Nil(t, err)
-		assert.Nil(t, v.LoadSchema(string(schema)))
+		pluginName, err := v.LoadSchema(string(schema))
+		assert.EqualValues(t, "key-auth", pluginName)
+		assert.Nil(t, err)
 	})
 	t.Run("loads a schema with entity checks", func(t *testing.T) {
 		schema, err := ioutil.ReadFile("testdata/rate-limiting.lua")
 		assert.Nil(t, err)
-		assert.Nil(t, v.LoadSchema(string(schema)))
+		pluginName, err := v.LoadSchema(string(schema))
+		assert.EqualValues(t, "rate-limiting", pluginName)
+		assert.Nil(t, err)
 	})
 	t.Run("fails to load a bad schema", func(t *testing.T) {
 		schema, err := ioutil.ReadFile("testdata/bad_schema.lua")
 		assert.Nil(t, err)
-		err = v.LoadSchema(string(schema))
+		pluginName, err := v.LoadSchema(string(schema))
+		assert.Empty(t, pluginName)
 		assert.NotNil(t, err)
 		expected := "name: field required for entity check"
 		assert.True(t, strings.Contains(err.Error(), expected))
@@ -49,7 +54,8 @@ func TestValidator_LoadSchema(t *testing.T) {
 	t.Run("fails to load a schema with invalid imports", func(t *testing.T) {
 		schema, err := ioutil.ReadFile("testdata/invalid_import_schema.lua")
 		assert.Nil(t, err)
-		err = v.LoadSchema(string(schema))
+		pluginName, err := v.LoadSchema(string(schema))
+		assert.Empty(t, pluginName)
 		assert.NotNil(t, err)
 	})
 }
@@ -59,13 +65,19 @@ func TestValidator_Validate(t *testing.T) {
 	assert.Nil(t, err)
 	schema, err := ioutil.ReadFile("testdata/uuid_schema.lua")
 	assert.Nil(t, err)
-	assert.Nil(t, v.LoadSchema(string(schema)))
+	pluginName, err := v.LoadSchema(string(schema))
+	assert.EqualValues(t, "test", pluginName)
+	assert.Nil(t, err)
 	schema, err = ioutil.ReadFile("testdata/key-auth.lua")
 	assert.Nil(t, err)
-	assert.Nil(t, v.LoadSchema(string(schema)))
+	pluginName, err = v.LoadSchema(string(schema))
+	assert.EqualValues(t, "key-auth", pluginName)
+	assert.Nil(t, err)
 	schema, err = ioutil.ReadFile("testdata/rate-limiting.lua")
 	assert.Nil(t, err)
-	assert.Nil(t, v.LoadSchema(string(schema)))
+	pluginName, err = v.LoadSchema(string(schema))
+	assert.EqualValues(t, "rate-limiting", pluginName)
+	assert.Nil(t, err)
 	t.Run("validates a uuid correctly", func(t *testing.T) {
 		plugin := `{
                      "name": "test",
@@ -148,7 +160,9 @@ func TestValidator_ProcessAutoFields(t *testing.T) {
 	assert.Nil(t, err)
 	schema, err := ioutil.ReadFile("testdata/key-auth.lua")
 	assert.Nil(t, err)
-	assert.Nil(t, v.LoadSchema(string(schema)))
+	pluginName, err := v.LoadSchema(string(schema))
+	assert.EqualValues(t, "key-auth", pluginName)
+	assert.Nil(t, err)
 	t.Run("populates defaults for key-auth plugin", func(t *testing.T) {
 		plugin := `{
                      "name": "key-auth",
@@ -192,7 +206,9 @@ func TestValidator_SchemaAsJSON(t *testing.T) {
 	for _, schemaName := range schemaNames {
 		schema, err := ioutil.ReadFile("testdata/" + schemaName + ".lua")
 		assert.Nil(t, err)
-		assert.Nil(t, v.LoadSchema(string(schema)))
+		pluginName, err := v.LoadSchema(string(schema))
+		assert.EqualValues(t, schemaName, pluginName)
+		assert.Nil(t, err)
 	}
 
 	t.Run("returns a valid JSON schema for loaded plugin schema", func(t *testing.T) {


### PR DESCRIPTION
Since the schemas are loaded as Lua files it is easier to get the plugin name that is being loaded by using the Lua VM. The filenames may not always dictate the exact name of the plugin and the `name` field is required by Kong Gateway for all the plugin schemas.

This change allows the code to be more dynamic when loading plugin information into memory for runtime use.