### PR TITLE
fix: ensure custom_entity_checks in schemas return error message

### DIFF
--- a/internal/vm/setup.go
+++ b/internal/vm/setup.go
@@ -40,8 +40,7 @@ _G["validate"] = function(plugin)
   if err then
     return nil, err
   end
-  local inspect = require "inspect"
-  local ok ,err = Plugins:validate(tbl)
+  local ok, err = Plugins:validate(tbl)
   if not ok then
     return nil, json.encode(err)
   end

--- a/lua-tree/share/lua/5.1/kong/db/schema/init.lua
+++ b/lua-tree/share/lua/5.1/kong/db/schema/init.lua
@@ -1223,7 +1223,7 @@ local function run_entity_check(self, name, input, arg, full_check, errors)
 
   else
     local error_fmt = validation_errors[name:upper()]
-    err = error_fmt and error_fmt:format(err) or err
+    local err = error_fmt and error_fmt:format(err) or err
     if not err then
       local data = pretty.write({ name = arg }):gsub("%s+", " ")
       err = validation_errors.ENTITY_CHECK:format(name, data)

--- a/patches/lua-tree.patch
+++ b/patches/lua-tree.patch
@@ -44,6 +44,7 @@ schema/init.lua:
 - Use go.uuid instead of uuid
 - use re_match as UUID match intad of re_find
 - remove log statements
+- ensure custom_entity_checks in schemas return error message
 
 
 schema/typedefs.lua:
@@ -234,6 +235,15 @@ index 734fbd5..0ddffad 100644
      else
        field, err = resolve_field(self, k, field, subschema)
        if field then
+@@ -1223,7 +1223,7 @@ local function run_entity_check(self, name, input, arg, full_check, errors)
+ 
+   else
+     local error_fmt = validation_errors[name:upper()]
+-    err = error_fmt and error_fmt:format(err) or err
++    local err = error_fmt and error_fmt:format(err) or err
+     if not err then
+       local data = pretty.write({ name = arg }):gsub("%s+", " ")
+       err = validation_errors.ENTITY_CHECK:format(name, data)
 @@ -2063,6 +2061,39 @@ local function allow_record_fields_by_name(record, loop)
  end
  

--- a/plugin/testdata/custom-entity-check.lua
+++ b/plugin/testdata/custom-entity-check.lua
@@ -1,0 +1,23 @@
+local typedefs = require "kong.db.schema.typedefs"
+return {
+  name = "custom-entity-check",
+  fields = {
+    {protocols = typedefs.protocols},
+    {config = {
+        type = "record",
+        fields = {
+          {strategy = {type = "string", default = "localhost", one_of = { "localhost", "other"}}},
+          {other = {type = "record", fields = {{host = typedefs.host}}}}
+  }}}},
+  entity_checks = {{
+    custom_entity_check = {
+      field_sources = { "config" },
+      fn = function(entity)
+        local config = entity.config
+        if config.strategy == "other" and (config.other == nil or config.other.host == nil) then
+          return nil, "custom-entity-check failed message"
+        end
+        return true
+      end
+  }}}
+}

--- a/plugin/testdata/inject_filesystem_schema.lua
+++ b/plugin/testdata/inject_filesystem_schema.lua
@@ -12,6 +12,7 @@ return {
         fields = {
           { shared = shared.config_schema},
         },
-     },
+      },
     },
-},}
+  },
+}

--- a/plugin/validator_test.go
+++ b/plugin/validator_test.go
@@ -231,6 +231,33 @@ func TestValidator_Validate(t *testing.T) {
 	})
 }
 
+func TestValidator_ValidateWithCustomEntityCheck(t *testing.T) {
+	v, err := NewValidator(ValidatorOpts{})
+	assert.Nil(t, err)
+	schema, err := ioutil.ReadFile("testdata/custom-entity-check.lua")
+	assert.Nil(t, err)
+	pluginName, err := v.LoadSchema(string(schema))
+	assert.Nil(t, err)
+	assert.EqualValues(t, "custom-entity-check", pluginName)
+
+	t.Run("fails and returns error message", func(t *testing.T) {
+		plugin := `{
+			"name": "custom-entity-check",
+			"config": {"strategy": "other"},
+			"enabled": true,
+			"protocols": ["http"]
+		}`
+		err := v.Validate(plugin)
+		assert.NotNil(t, err)
+		expected := `{
+			"@entity": [
+				"custom-entity-check failed message"
+			]
+		}`
+		require.JSONEq(t, expected, err.Error())
+	})
+}
+
 func TestValidator_ProcessAutoFields(t *testing.T) {
 	v, err := NewValidator(ValidatorOpts{})
 	assert.Nil(t, err)


### PR DESCRIPTION
The LuaVM has a scoping (or initialization) issue when a variable defined in a parent scope is used as the var and value for and/or (ternary) solutions. Correcting the scope or changing the variable name (if possible) in child scope corrects the issue.