### PR TITLE
tests: add test cases to exercise typedefs validation 

### DIFF
--- a/lua-tree/share/lua/5.1/kong/db/schema/typedefs.lua
+++ b/lua-tree/share/lua/5.1/kong/db/schema/typedefs.lua
@@ -86,7 +86,7 @@ end
 
 
 local function validate_name(name)
-  if not match(name, "^[%w%.%-%_~]+$") then
+  if not match(name, "^[\\w\\.\\-\\_~]+$") then
     return nil,
     "invalid value '" .. name ..
       "': it must only contain alphanumeric and '., -, _, ~' characters"
@@ -133,7 +133,7 @@ local function validate_utf8_name(name)
     return nil, err
   end
 
-  if not match(name, "^[%w%.%-%_~\128-\244]+$") then
+  if not match(name, "^[\\w\\.\\-\\_~\\x80-\\xF4]+$") then
     return nil,
     "invalid value '" .. name ..
       "': the only accepted ascii characters are alphanumerics or ., -, _, and ~"

--- a/patches/lua-tree.patch
+++ b/patches/lua-tree.patch
@@ -304,8 +304,17 @@ index c1a150a..3d6c639 100644
                       "]*$")
    then
      return nil,
-@@ -118,7 +116,7 @@ local function validate_tag(tag)
- 
+@@ -88,7 +87,7 @@ end
+
+
+ local function validate_name(name)
+-  if not match(name, "^[%w%.%-%_~]+$") then
++  if not match(name, "^[\\w\\.\\-\\_~]+$") then
+     return nil,
+     "invalid value '" .. name ..
+       "': it must only contain alphanumeric and '., -, _, ~' characters"
+@@ -118,7 +117,7 @@ local function validate_tag(tag)
+
    -- printable ASCII (33-126 except ','(44) and '/'(47),
    -- plus non-ASCII utf8 (128-244)
 -  if not match(tag, "^[\033-\043\045\046\048-\126\128-\244]+$") then
@@ -313,7 +322,16 @@ index c1a150a..3d6c639 100644
      return nil,
      "invalid tag '" .. tag ..
        "': expected printable ascii (except `,` and `/`) or valid utf-8 sequences"
-@@ -216,22 +214,12 @@ end
+@@ -135,7 +134,7 @@ local function validate_utf8_name(name)
+     return nil, err
+   end
+
+-  if not match(name, "^[%w%.%-%_~\128-\244]+$") then
++  if not match(name, "^[\\w\\.\\-\\_~\\x80-\\xF4]+$") then
+     return nil,
+     "invalid value '" .. name ..
+       "': the only accepted ascii characters are alphanumerics or ., -, _, and ~"
+@@ -216,22 +215,12 @@ end
  
  
  local function validate_certificate(cert)

--- a/plugin/testdata/all-typedefs.lua
+++ b/plugin/testdata/all-typedefs.lua
@@ -1,0 +1,42 @@
+local typedefs = require "kong.db.schema.typedefs"
+
+return {
+  name = "all-typedefs",
+  fields = {
+    { protocols = typedefs.protocols_http },
+    { config = {
+        type = "record",
+        fields = {
+          { http_method = typedefs.http_method },
+          { protocol = typedefs.protocol },
+          { host = typedefs.host },
+          { host_with_optional_port = typedefs.host_with_optional_port },
+          { wildcard_host = typedefs.wildcard_host },
+          { ip = typedefs.ip },
+          { ip_or_cidr = typedefs.ip_or_cidr },
+          { cidr_v4 = typedefs.cidr_v4 },
+          { port = typedefs.port },
+          { path = typedefs.path },
+          { url = typedefs.url },
+          { header_name = typedefs.header_name },
+          { timeout = typedefs.timeout },
+          { uuid = typedefs.uuid },
+          { auto_timestamp_s = typedefs.auto_timestamp_s },
+          { auto_timestamp_ms = typedefs.auto_timestamp_ms },
+          { name = typedefs.name },
+          { utf8_name = typedefs.utf8_name },
+          { sni = typedefs.sni },
+          { key = typedefs.key },
+          { tag = typedefs.tag({ required = false }) },
+          { tags = typedefs.tags },
+          { sources = typedefs.sources },
+          { destinations = typedefs.destinations },
+          { hosts = typedefs.hosts },
+          { paths = typedefs.paths },
+          { semantic_version = typedefs.semantic_version },
+          { lua_code = typedefs.lua_code },
+        },
+      },
+    },
+  },
+}

--- a/plugin/testdata/methods-and-headers.lua
+++ b/plugin/testdata/methods-and-headers.lua
@@ -1,0 +1,16 @@
+local typedefs = require "kong.db.schema.typedefs"
+
+return {
+  name = "methods-and-headers",
+  fields = {
+    { protocols = typedefs.protocols_http },
+    { config = {
+        type = "record",
+        fields = {
+          { methods = typedefs.methods },
+          { headers = typedefs.headers },
+        },
+      },
+    },
+  },
+}


### PR DESCRIPTION
In order to have comprehensive tests, we are introducing some
fake plugins whose schemas are composed of typedefs fields,
in order to test their respective custom validators.

A few notes:
- I split the fake plugin into 2 because of some odd behaviour I could see while testing: the `methods` field in a set of `http_method`; if both `methods` and `http_method` are part of the plugin schema, and only the `methods` field is filled, then the validation fails because `http_method` becomes _required_ somehow. Same goes with the `headers` and `header_name` fields. This need further investigation, but for the sake of this test I've separated these fields into different plugins
- The custom validator for the `key` field is not implemented yet: https://github.com/Kong/goks/blob/main/patches/lua-tree.patch#L330-L337
- I caught what I believe to be a bug in the validator for the `url` field: if it's passed an `url` without a protocol, the validator returns an error suggesting what's missing is actually the host part.

```
		// BUG: a URL with missing protocol results into a 'missing host in url' error
		{
			name: "invalid url",
			config: `{
				"url": "www.konghq.com",
				"tag": "test"
			}`,
			wantErr:     true,
			expectedErr: `{"config":{"url":"missing protocol in url"}}`,
		},
```
This happens in Kong too:

```
$ echo '                                                                                                                                                                                                                                                                                                        
name: http-log
config:
    http_endpoint: www.konghq.com
' | y2j | http put ":8001/plugins/9c8047db-b57e-43a9-8a41-dd83a302a1b8"
HTTP/1.1 400 Bad Request

{
    "code": 2,
    "fields": {
        "config": {
            "http_endpoint": "missing host in url"
        }
    },
    "message": "schema violation (config.http_endpoint: missing host in url)",
    "name": "schema violation"
}
```