### PR TITLE
feat: adding validate and unload plugin schema functionality

### DIFF
--- a/plugin/validator.go
+++ b/plugin/validator.go
@@ -22,9 +22,18 @@ func NewValidator(opts ValidatorOpts) (*Validator, error) {
 	return &Validator{vm: vm}, nil
 }
 
+func (v *Validator) ValidateSchema(schema string) (string, error) {
+	return v.vm.CallByParams("validate_plugin_schema", schema)
+}
+
 func (v *Validator) LoadSchema(schema string) (string, error) {
 	pluginName, err := v.vm.CallByParams("load_plugin_schema", schema)
 	return pluginName, err
+}
+
+func (v *Validator) UnloadSchema(schema string) error {
+	_, err := v.vm.CallByParams("unload_plugin_schema", schema)
+	return err
 }
 
 func (v *Validator) Validate(pluginInstance string) error {

--- a/plugin/validator.go
+++ b/plugin/validator.go
@@ -27,8 +27,7 @@ func (v *Validator) ValidateSchema(schema string) (string, error) {
 }
 
 func (v *Validator) LoadSchema(schema string) (string, error) {
-	pluginName, err := v.vm.CallByParams("load_plugin_schema", schema)
-	return pluginName, err
+	return v.vm.CallByParams("load_plugin_schema", schema)
 }
 
 func (v *Validator) UnloadSchema(schema string) error {


### PR DESCRIPTION
These feature additions allow for plugin:

* schema to be validated loading and potentially overriding plugin definitions which have already been loaded into the plugins subschemas definitions
* unloading of plugin schemas; useful for removing a plugin schema during runtime