### PR TITLE
fix: use ngx.null for nil check on null map values

### DIFF
--- a/lua-tree/share/lua/5.1/kong/db/schema/init.lua
+++ b/lua-tree/share/lua/5.1/kong/db/schema/init.lua
@@ -1667,7 +1667,7 @@ function Schema:process_auto_fields(data, context, nulls, opts)
         end
 
       elseif ftype == "string" then
-        if is_insert_or_upsert and value == nil then
+        if is_insert_or_upsert and value == null then
           value = random_string()
         end
 

--- a/patches/lua-tree.patch
+++ b/patches/lua-tree.patch
@@ -161,7 +161,7 @@ index b1093a2..0afc200 100644
  
  local tostring = tostring
 diff --git a/lua-tree/share/lua/5.1/kong/db/schema/init.lua b/lua-tree/share/lua/5.1/kong/db/schema/init.lua
-index 625bb0c63..956a09ec9 100644
+index 625bb0c63..3c7126165 100644
 --- a/lua-tree/share/lua/5.1/kong/db/schema/init.lua
 +++ b/lua-tree/share/lua/5.1/kong/db/schema/init.lua
 @@ -1,16 +1,12 @@
@@ -215,8 +215,7 @@ index 625bb0c63..956a09ec9 100644
      else
        field, err = resolve_field(self, k, field, subschema)
        if field then
-        print("check_name (condition) = " .. require("inspect")(check_name))
-@@ -1210,12 +1207,6 @@ local function run_entity_check(self, name, input, arg, full_check, errors)
+@@ -1217,12 +1207,6 @@ local function run_entity_check(self, name, input, arg, full_check, errors)
        end
      else
        all_nil = false
@@ -254,6 +253,15 @@ index 625bb0c63..956a09ec9 100644
 
    for key, field in self:each_field(data) do
      local ftype = field.type
+@@ -1690,7 +1667,7 @@ function Schema:process_auto_fields(data, context, nulls, opts)
+         end
+
+       elseif ftype == "string" then
+-        if is_insert_or_upsert and value == nil then
++        if is_insert_or_upsert and value == null then
+           value = random_string()
+         end
+
 diff --git a/lua-tree/share/lua/5.1/kong/db/schema/plugin_loader.lua b/lua-tree/share/lua/5.1/kong/db/schema/plugin_loader.lua
 index abcab8c..96e6d3d 100644
 --- a/lua-tree/share/lua/5.1/kong/db/schema/plugin_loader.lua


### PR DESCRIPTION
Right now, whenever a map containing some nil values is passed
to the process_auto_fields function, the code fails to
recognize it applying the wrong logic to it.

This commit makes sure this doesn't happen by performing the
nil check on `ngx.null` instead of `nil`.