### PR TITLE
fix: ensure string auto fields can be generated

### DIFF
--- a/lua-tree/share/lua/5.1/kong/db/schema/init.lua
+++ b/lua-tree/share/lua/5.1/kong/db/schema/init.lua
@@ -1667,7 +1667,7 @@ function Schema:process_auto_fields(data, context, nulls, opts)
         end
 
       elseif ftype == "string" then
-        if is_insert_or_upsert and value == null then
+        if is_insert_or_upsert and (value == null or value == nil) then
           value = random_string()
         end
 

--- a/lualibs/go/ngx/time.go
+++ b/lualibs/go/ngx/time.go
@@ -13,14 +13,18 @@ func GetNgxTime(l *lua.LState) int {
 }
 
 func GetNgxNow(l *lua.LState) int {
+	now := Now()
+	l.Push(lua.LNumber(now))
+	return 1
+}
+
+func Now() float64 {
 	t := time.Now()
 	seconds := t.Unix()
 	var secondMultiplier int64 = 1000
 	msDivisor := 1000.0
 	miliseconds := t.UnixMilli() - seconds*secondMultiplier
-	result := float64(seconds) + float64(miliseconds)/msDivisor
-	l.Push(lua.LNumber(result))
-	return 1
+	return float64(seconds) + float64(miliseconds)/msDivisor
 }
 
 func UpdateTime(_ *lua.LState) int {

--- a/patches/lua-tree.patch
+++ b/patches/lua-tree.patch
@@ -258,7 +258,7 @@ index 625bb0c63..3c7126165 100644
 
        elseif ftype == "string" then
 -        if is_insert_or_upsert and value == nil then
-+        if is_insert_or_upsert and value == null then
++        if is_insert_or_upsert and (value == null or value == nil) then
            value = random_string()
          end
 

--- a/plugin/testdata/auto-fields.lua
+++ b/plugin/testdata/auto-fields.lua
@@ -1,0 +1,18 @@
+local typedefs = require "kong.db.schema.typedefs"
+
+return {
+  name = "auto-fields",
+  fields = {
+    { protocols = typedefs.protocols_http },
+    { config = {
+        type = "record",
+        fields = {
+          { string = { type = "string", auto = true, required = true } },
+          { uuid = typedefs.uuid({ auto = true, required = true }) },
+          { created_at = { type = "number", auto = true, required = true } },
+          { updated_at = { type = "integer", auto = true, required = true } },
+        },
+      },
+    },
+  },
+}


### PR DESCRIPTION
This fixes an issue where the value for an auto generate string is either ngx.null or nil which have two different meaning in goks as OpenResty is not used.